### PR TITLE
Prevent AssertionError

### DIFF
--- a/src/rinoh/document.py
+++ b/src/rinoh/document.py
@@ -454,13 +454,13 @@ to the terms of the GNU Affero General Public License version 3.''')
                                     if isinstance(flowable, Section)):
             section_number = self.get_reference(section_id, NUMBER)
             section_title = self.get_reference(section_id, TITLE)
-            if section.level > current_level:
-                assert section.level == current_level + 1
+            if section.level == current_level + 1:
                 stack.append(parent)
                 parent = current
             elif section.level < current_level:
                 for i in range(current_level - section.level):
-                    parent = stack.pop()
+                    if stack:
+                        parent = stack.pop()
             current = []
             item = (str(section_id), section_number, section_title, current)
             parent.append(item)


### PR DESCRIPTION
For ununderstood reasons, my sphinx tree fails to build with the following stacktrace. This patch prevent this. I do not really understand what happened here so any comment is welcomed : )

Please let me know if I can add information.

```
Not yet converged, rendering again...
100% [========================================] ETA 00:00 (00:53)

Exception occurred:
  File "/home/goudale/.virtualenvs/diplodocus3/lib/python3.5/site-packages/rinoh/document.py", line 458, in create_outlines
    assert section.level == current_level + 1
AssertionError
The full traceback has been saved in /tmp/sphinx-err-tyt5znkg.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:149: rinoh] Error 1
```
