### PR TITLE
Fix source suffix where configured as a list.

### DIFF
--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -222,7 +222,11 @@ class RinohBuilder(Builder):
 
     def write_doc(self, docname, doctree, docnames, targetname):
         config = self.config
-        suffix, = config.source_suffix
+        suffix = (
+            config.source_suffix[0]
+            if isinstance(config.source_suffix, list)
+            else config.source_suffix
+        )
         source_path = os.path.join(self.srcdir, docname + suffix)
         parser = ReStructuredTextReader()
         rinoh_tree = parser.from_doctree(source_path, doctree)


### PR DESCRIPTION
Fixes where `source_suffix` is a list of more than one extensions.