### PR TITLE
Use IndexError as parent of NoMoreParentElement

### DIFF
--- a/src/rinoh/style.py
+++ b/src/rinoh/style.py
@@ -395,7 +395,7 @@ class ContextSelector(Selector):
         return total_score
 
 
-class NoMoreParentElement(StopIteration):
+class NoMoreParentElement(IndexError):
     """The top-level element in the document element tree has been reached"""
 
 


### PR DESCRIPTION
Use IndexError instead of StopIteration as super class of
NoMoreParentElement. generator functions like styled_and_parents should not raise
StopIteration any more due to PEP479. Changing StopIteration to
IndexError is imo the most less intrusive way and follows the rinohtype logic.