### PR TITLE
Cache AttributeType.from_string()

### DIFF
--- a/src/rinoh/attribute.py
+++ b/src/rinoh/attribute.py
@@ -40,6 +40,7 @@ class AttributeType(object):
         return isinstance(value, cls)
 
     @classmethod
+    @cached
     def from_string(cls, string):
         return cls.parse_string(string)
 


### PR DESCRIPTION
Adding the `@cached` decorator to AttributeType.from_string() halved the rendering time in my test document.

Before caching this method is computed 7919 times, after caching it is computed only 138 times.