### PR TITLE
Remove support for latex_* options

### DIFF
--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -191,7 +191,7 @@ class RinohBuilder(Builder, Source):
                     yield IndexSection(SingleStyledText(index_section_label),
                                        index_flowables(content))
 
-    def init_document_data(self):
+    def init_document_data(self, logger):
         document_data = []
         # assign subdirs to titles
         self.titles = []
@@ -209,7 +209,7 @@ class RinohBuilder(Builder, Source):
 
     def write(self, *ignored):
         variable_removed_warnings(self.config, logger)
-        document_data = self.init_document_data()
+        document_data = self.init_document_data(logger)
         for entry in document_data:
             docname, targetname, title, author = entry[:4]
             toctree_only = entry[4] if len(entry) > 4 else False
@@ -305,7 +305,7 @@ def latex_document_to_rinoh_document(entry, logger):
     startdocname, targetname, title, author, documentclass = entry[:5]
     toctree_only = entry[5] if len(entry) > 5 else False
     targetname_root, _ = os.path.splitext(targetname)
-    return startdocname, targetname_root, title, author, toctree_only
+    return [startdocname, targetname_root, title, author, toctree_only]
 
 
 def variable_removed_warnings(config, logger):

--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -311,11 +311,6 @@ def default_documents(config):
             for entry in config.latex_documents]
 
 
-def default_logo(config):
-    info_config_conversion('logo')
-    return config.latex_logo
-
-
 def default_domain_indices(config):
     info_config_conversion('domain_indices')
     return config.latex_domain_indices
@@ -333,7 +328,7 @@ def variable_removed_warnings(config, logger):
 def setup(app):
     app.add_builder(RinohBuilder)
     app.add_config_value('rinoh_documents', default_documents, 'env')
-    app.add_config_value('rinoh_logo', default_logo, 'html')
+    app.add_config_value('rinoh_logo', None, 'html')
     app.add_config_value('rinoh_domain_indices', default_domain_indices, 'html')
     app.add_config_value('rinoh_template', 'book', 'html')
     app.add_config_value('rinoh_metadata', dict(), 'html')

--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -311,11 +311,6 @@ def default_documents(config):
             for entry in config.latex_documents]
 
 
-def default_domain_indices(config):
-    info_config_conversion('domain_indices')
-    return config.latex_domain_indices
-
-
 def variable_removed_warnings(config, logger):
     message = ("Support for '{}' has been removed. Instead, please specify"
                " the {} to use in your template configuration.")
@@ -329,7 +324,7 @@ def setup(app):
     app.add_builder(RinohBuilder)
     app.add_config_value('rinoh_documents', default_documents, 'env')
     app.add_config_value('rinoh_logo', None, 'html')
-    app.add_config_value('rinoh_domain_indices', default_domain_indices, 'html')
+    app.add_config_value('rinoh_domain_indices', None, 'html')
     app.add_config_value('rinoh_template', 'book', 'html')
     app.add_config_value('rinoh_metadata', dict(), 'html')
     app.add_config_value('rinoh_stylesheet', None, 'html')

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -78,8 +78,15 @@ def test_sphinx_config_latex_elements_papersize_no_effect(tmp_path):
     assert get_contents_page_size(template_cfg) == A4
 
 
-def test_sphinx_config_language(tmp_path):
-    template_cfg = get_template_cfg(tmp_path, language='it')
+def test_sphinx_config_latex_logo_no_effect(caplog, tmpdir):
+    expected_logo = "logo.png"
+    app = create_sphinx_app(tmpdir, latex_logo=expected_logo)
+    assert app.config.latex_logo == expected_logo
+    assert app.config.rinoh_logo is None
+
+
+def test_sphinx_config_language(tmpdir):
+    template_cfg = get_template_cfg(tmpdir, language='it')
     assert template_cfg.template == Book
     assert template_cfg['language'] == IT
 
@@ -147,8 +154,8 @@ def test_sphinx_set_document_metadata_subtitle(tmp_path):
 
 def test_sphinx_set_document_metadata_logo(tmp_path):
     expected_logo = 'logo.png'
-    app = create_sphinx_app(tmp_path, rinoh_logo='logo.png')
-    template_cfg = app.builder.template_from_config(LOGGER)
+    app = create_sphinx_app(tmpdir, rinoh_logo=expected_logo)
+    template_cfg = template_from_config(app.config, CONFIG_DIR, LOGGER)
     docutil_tree = create_document()
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -199,49 +199,51 @@ def test_sphinx_rinoh_paper_size_removed(caplog, tmp_path):
     assert "Support for 'rinoh_paper_size' has been removed" in caplog.text
 
 
-def test_sphinx_init_document_data_rinoh_documents(tmp_path):
+def test_sphinx_document_data_rinoh_documents(tmp_path):
     rinoh_documents = [['index', 'rinoh_doc', 'Title', 'Author', False]]
     app = create_sphinx_app(tmp_path, rinoh_documents=rinoh_documents)
-    document_data = app.builder.init_document_data(LOGGER)
+    document_data = app.builder.document_data(LOGGER)
     assert document_data == rinoh_documents
 
 
-def test_sphinx_init_document_data_rinoh_documents_unknown(caplog, tmp_path):
+def test_sphinx_document_data_rinoh_documents_unknown(caplog, tmp_path):
     rinoh_documents = [['not_here', 'rinoh_doc', 'Title', 'Author', False]]
     app = create_sphinx_app(tmp_path, rinoh_documents=rinoh_documents)
     with caplog.at_level(logging.WARNING):
-        document_data = app.builder.init_document_data(LOGGER)
+        document_data = app.builder.document_data(LOGGER)
     assert not document_data
     assert ('"rinoh_documents" config value references unknown document '
             'not_here') in caplog.text
 
+
 @pytest.mark.this_one
-def test_sphinx_init_document_data_no_rinoh_documents(caplog, tmp_path):
+def test_sphinx_document_data_no_rinoh_documents(caplog, tmp_path):
     app = create_sphinx_app(tmp_path, latex_documents=None)
     with caplog.at_level(logging.WARNING):
-        document_data = app.builder.init_document_data(LOGGER)
+        document_data = app.builder.document_data(LOGGER)
     assert not document_data
     assert ('no "rinoh_documents" config value found; no documents will be'
             ' written') in caplog.text
 
 
-def test_sphinx_init_document_data_latex_documents_fallback(caplog, tmp_path):
+def test_sphinx_document_data_latex_documents_fallback(caplog, tmp_path):
     latex_documents = [['index', 'doc.tex', 'Title', 'Author', 'manual', True]]
     rinoh_documents = [['index', 'doc', 'Title', 'Author', True]]
     app = create_sphinx_app(tmp_path, latex_documents=latex_documents)
     with caplog.at_level(logging.WARNING):
-        document_data = app.builder.init_document_data(LOGGER)
+        document_data = app.builder.document_data(LOGGER)
     assert document_data == rinoh_documents
     assert ("'rinoh_documents' config variable not set, automatically"
             " converting from 'latex_documents'") in caplog.text
 
 
-def test_sphinx_init_document_data_latex_documents_ignored(caplog, tmp_path):
+def test_sphinx_document_data_latex_documents_ignored(caplog, tmp_path):
     latex_documents = [['index', 'doc.tex', 'Title', 'Author', 'manual', True]]
     rinoh_documents = [['index', 'rinoh_doc', 'Title', 'Author', False]]
-    app = create_sphinx_app(tmp_path, rinoh_documents=rinoh_documents, latex_documents=latex_documents)
+    app = create_sphinx_app(
+        tmp_path, rinoh_documents=rinoh_documents, latex_documents=latex_documents)
     with caplog.at_level(logging.WARNING):
-        document_data = app.builder.init_document_data(LOGGER)
+        document_data = app.builder.document_data(LOGGER)
     assert document_data == rinoh_documents
     assert ("'rinoh_documents' config variable not set, automatically"
             " converting from 'latex_documents'") not in caplog.text
@@ -249,10 +251,9 @@ def test_sphinx_init_document_data_latex_documents_ignored(caplog, tmp_path):
 
 def test_sphinx_titles(caplog, tmp_path):
     rinoh_documents = [['index', 'rinoh_doc', 'Title', 'Author', False],
-    ['other/index', 'rinoh_doc', 'Other Title', 'Other Author']]
+                       ['other/index', 'rinoh_doc', 'Other Title', 'Other Author']]
     all_docs = [doc[0] for doc in rinoh_documents]
-    app = create_sphinx_app(tmp_path, all_docs=all_docs, rinoh_documents=rinoh_documents)
-    with caplog.at_level(logging.WARNING):
-        _ = app.builder.init_document_data(LOGGER)
-        titles = app.builder.titles
+    app = create_sphinx_app(tmp_path, all_docs=all_docs,
+                            rinoh_documents=rinoh_documents)
+    titles = app.builder.titles
     assert titles == [('index', "Title"), ('other/', "Other Title")]

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -17,8 +17,8 @@ from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 
 from rinoh.document import DocumentTree
-from rinoh.frontend.sphinx import (template_from_config, set_document_metadata,
-                                   variable_removed_warnings, preliminary_document_data)
+from rinoh.frontend.sphinx import (
+    variable_removed_warnings, preliminary_document_data)
 from rinoh.language import IT
 from rinoh.paper import A4
 from rinoh.templates import Book, Article
@@ -81,18 +81,18 @@ def test_sphinx_config_latex_elements_papersize_no_effect(tmp_path):
 
 @pytest.mark.parametrize('latex_option, value', (('latex_logo', 'logo.png'),
                                                  ('latex_domain_indices', True)))
-def test_sphinx_config_latex_option_no_effect(latex_option, value, tmpdir):
+def test_sphinx_config_latex_option_no_effect(latex_option, value, tmp_path):
     confoverrides = {latex_option: value}
-    app = create_sphinx_app(tmpdir, **confoverrides)
+    app = create_sphinx_app(tmp_path, **confoverrides)
     rinoh_option = latex_option.replace("latex", "rinoh")
     assert getattr(app.config, latex_option) == value
     assert getattr(app.config, rinoh_option) is None
 
 
-def test_sphinx_config_latex_documents_fallback(caplog, tmpdir):
+def test_sphinx_config_latex_documents_fallback(caplog, tmp_path):
     latex_documents = [('index', 'doc.tex', 'Title', 'Author', 'manual', True)]
     rinoh_documents = [('index', 'doc', 'Title', 'Author', True)]
-    app = create_sphinx_app(tmpdir, latex_documents=latex_documents)
+    app = create_sphinx_app(tmp_path, latex_documents=latex_documents)
     with caplog.at_level(logging.WARNING):
         documents = preliminary_document_data(app.config, LOGGER)
     assert documents == rinoh_documents
@@ -100,11 +100,11 @@ def test_sphinx_config_latex_documents_fallback(caplog, tmpdir):
             " converting from 'latex_documents'") in caplog.text
 
 
-def test_sphinx_config_latex_documents_ignored(capsys, tmpdir):
+def test_sphinx_config_latex_documents_ignored(capsys, tmp_path):
     latex_documents = [('index', 'doc.tex', 'Title', 'Author', 'manual', True)]
     rinoh_documents = [('index', 'rinoh_doc', 'Title', 'Author', False)]
     app = create_sphinx_app(
-        tmpdir, rinoh_documents=rinoh_documents, latex_documents=latex_documents)
+        tmp_path, rinoh_documents=rinoh_documents, latex_documents=latex_documents)
     stdout, stderr = capsys.readouterr()
     assert app.config.rinoh_documents == rinoh_documents
     assert ("'rinoh_documents' config variable not set, automatically"
@@ -112,8 +112,9 @@ def test_sphinx_config_latex_documents_ignored(capsys, tmpdir):
     assert ("'rinoh_documents' config variable not set, automatically"
             " converting from 'latex_documents'") not in stderr
 
-def test_sphinx_config_language(tmpdir):
-    template_cfg = get_template_cfg(tmpdir, language='it')
+
+def test_sphinx_config_language(tmp_path):
+    template_cfg = get_template_cfg(tmp_path, language='it')
     assert template_cfg.template == Book
     assert template_cfg['language'] == IT
 
@@ -181,8 +182,8 @@ def test_sphinx_set_document_metadata_subtitle(tmp_path):
 
 def test_sphinx_set_document_metadata_logo(tmp_path):
     expected_logo = 'logo.png'
-    app = create_sphinx_app(tmpdir, rinoh_logo=expected_logo)
-    template_cfg = template_from_config(app.config, CONFIG_DIR, LOGGER)
+    app = create_sphinx_app(tmp_path, rinoh_logo=expected_logo)
+    template_cfg = app.builder.template_from_config(LOGGER)
     docutil_tree = create_document()
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -78,11 +78,14 @@ def test_sphinx_config_latex_elements_papersize_no_effect(tmp_path):
     assert get_contents_page_size(template_cfg) == A4
 
 
-def test_sphinx_config_latex_logo_no_effect(caplog, tmpdir):
-    expected_logo = "logo.png"
-    app = create_sphinx_app(tmpdir, latex_logo=expected_logo)
-    assert app.config.latex_logo == expected_logo
-    assert app.config.rinoh_logo is None
+@pytest.mark.parametrize('latex_option, value', (('latex_logo', 'logo.png'),
+                                                 ('latex_domain_indices', True)))
+def test_sphinx_config_latex_option_no_effect(latex_option, value, tmpdir):
+    confoverrides = {latex_option: value}
+    app = create_sphinx_app(tmpdir, **confoverrides)
+    rinoh_option = latex_option.replace("latex", "rinoh")
+    assert getattr(app.config, latex_option) == value
+    assert getattr(app.config, rinoh_option) is None
 
 
 def test_sphinx_config_language(tmpdir):


### PR DESCRIPTION
This PR removes the support for the latex_logo and latex_domain_indices options.

The bug reported in #175 is resolved, however because sphinx will always greedily calculate the default values it is not possible to convert `latex_documents` to `rinoh_documents` as a default function in `app.add_config_value(...)`.

Unit test coverage has been increased and a bit of refactoring has been performed to aid in testing and as preparation to convert `rinoh_documents` to accepting `dict` values.

