### PR TITLE
I77 rinoh document dicts

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ import time
 from distutils.core import run_setup
 
 import pkg_resources
+from sphinx.addnodes import toctree
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -365,8 +366,13 @@ epub_exclude_files = ['search.html']
 
 # -- Options for rinohtype PDF output -------------------------------------
 
-rinoh_documents = [('index', 'rinohtype', 'rinohtype',
-                    'Brecht Machiels', False)]
+rinoh_documents = [{
+    'doc': 'index',
+    'target': 'rinohtype',
+    'title': 'rinohtype',
+    'author': 'Brecht Machiels',
+    'toctree_only': False
+}]
 
 rinoh_template = 'rinohtype.rtt'
 rinoh_logo = '_static/rinohtype_logo.pdf'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -371,10 +371,10 @@ rinoh_documents = [{
     'target': 'rinohtype',
     'title': 'rinohtype',
     'author': 'Brecht Machiels',
-    'toctree_only': False
+    'toctree_only': False,
+    'template': 'rinohtype.rtt'
 }]
 
-rinoh_template = 'rinohtype.rtt'
 rinoh_logo = '_static/rinohtype_logo.pdf'
 
 # -- Extension interface -------------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -372,10 +372,9 @@ rinoh_documents = [{
     'title': 'rinohtype',
     'author': 'Brecht Machiels',
     'toctree_only': False,
-    'template': 'rinohtype.rtt'
+    'template': 'rinohtype.rtt',
+    'logo': '_static/rinohtype_logo.pdf'
 }]
-
-rinoh_logo = '_static/rinohtype_logo.pdf'
 
 # -- Extension interface -------------------------------------------------------
 

--- a/doc/sphinx.rst
+++ b/doc/sphinx.rst
@@ -11,22 +11,46 @@ options. Of these, only :confval:`rinoh_documents` (or
 .. confval:: rinoh_documents
 
     Determines how to group the document tree into PDF output files. Its format
-    is identical to that of :confval:`sphinx:latex_documents`, with the
-    exception that `targetname` should specify the name of the PDF file without
-    the extension. If it is not specified, the value of
-    :confval:`sphinx:latex_documents` is used instead (with the ``.tex``
-    extension stripped from the `targetname`).
+    is a list of dictionaries, one for each document to be generated. Supported
+    keys:
+
+    doc
+        String that specifies the name of the master document (typically
+        ``index``).
+    target
+        The name of the target PDF file without the extension.
+    title
+        The title of the document.
+    author
+        The author of the document.
+    toctree_only
+        Must be True or False. If true, the document itself is not included in
+        the output, only the documents referenced by it via TOC trees.
+        Default: ``False``.
+    logo
+        Path (relative to the configuration directory) to an image file to use at
+        the top of the title page. (Optional)
+    domain_indices
+        If true, generate domain-specific indices in addition to the general
+        index. It is equivalent to the :confval:`sphinx:html_domain_indices`
+        and :confval:`sphinx:latex_domain_indices` configuration variables.
+        Default: ``True``.
+    template
+        Determines the template used to render the document. It takes:
+
+        * the filename of a :ref:`template configuration file <configure_templates>`,
+        * a :class:`.TemplateConfiguration` instance,
+        * the name of an installed template (see :option:`rinoh --list-templates`)
+        * a :class:`.DocumentTemplate` subclass
+
+        The default is ``'book'``, which resolves to the :class:`.Book` template.
+
 
 .. confval:: rinoh_template
 
-    Determines the template used to render the document. It takes:
+    This configuration variable is **no longer supported** since the
+    domain_indices can be specified in the :confval:`rinoh_documents`.
 
-    * the filename of a :ref:`template configuration file <configure_templates>`,
-    * a :class:`.TemplateConfiguration` instance,
-    * the name of an installed template (see :option:`rinoh --list-templates`)
-    * a :class:`.DocumentTemplate` subclass
-
-    The default is ``'book'``, which resolves to the :class:`.Book` template.
 
 .. confval:: rinoh_stylesheet
 
@@ -67,15 +91,13 @@ options. Of these, only :confval:`rinoh_documents` (or
 
 .. confval:: rinoh_logo
 
-    Path (relative to the configuration directory) to an image file to use at
-    the top of the title page.
+    This configuration variable is **no longer supported** since the logo can
+    be specified in the :confval:`rinoh_documents`.
 
 .. confval:: rinoh_domain_indices
 
-    If true, generate domain-specific indices in addition to the general index.
-    It is equivalent to the :confval:`sphinx:html_domain_indices` and
-    :confval:`sphinx:latex_domain_indices` configuration variables. Default:
-    ``True``.
+    This configuration variable is **no longer supported** since the
+    domain_indices can be specified in the :confval:`rinoh_documents`.
 
 .. confval:: rinoh_metadata
 

--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -289,8 +289,8 @@ class RinohBuilder(Builder, Source):
 
     def set_document_metadata(self, rinoh_document, document_data):
         metadata = rinoh_document.metadata
-        if self.config.rinoh_logo:
-            rinoh_logo = Path(self.config.rinoh_logo)
+        if 'logo' in document_data:
+            rinoh_logo = Path(document_data['logo'])
             if not rinoh_logo.is_absolute():
                 rinoh_logo = self.confdir / rinoh_logo
             metadata['logo'] = rinoh_logo
@@ -345,6 +345,9 @@ def variable_removed_warnings(config, logger):
     if config.rinoh_template:
         logger.warning(message.format('rinoh_template',
                                       'template', "'rinoh_documents'"))
+    if config.rinoh_logo:
+        logger.warning(message.format('rinoh_logo',
+                                      'logo', "'rinoh_documents'"))
 
 
 def setup(app):

--- a/src/rinoh/frontend/sphinx/__init__.py
+++ b/src/rinoh/frontend/sphinx/__init__.py
@@ -231,8 +231,11 @@ class RinohBuilder(Builder, Source):
         variable_removed_warnings(self.config, logger)
         document_data = self.document_data(logger)
         for entry in document_data:
-            docname, targetname, title, author = entry[:4]
-            toctree_only = entry[4] if len(entry) > 4 else False
+            docname = entry['doc']
+            targetname = entry['target']
+            title = entry['title']
+            author = entry['author']
+            toctree_only = entry.get('toctree_only', False)
             logger.info("processing " + targetname + "... ", nonl=1)
             doctree, docnames = self.assemble_doctree(docname, toctree_only)
             self.preprocess_tree(doctree)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -84,7 +84,7 @@ def test_sphinx_config_latex_option_no_effect(tmp_path):
     assert app.config.latex_logo == 'logo.png'
     assert app.config.rinoh_logo is None
     assert app.config.latex_domain_indices == False
-    assert app.config.rinoh_domain_indices is True
+    assert app.config.rinoh_domain_indices is None
 
 
 def test_sphinx_config_language(tmp_path):
@@ -215,6 +215,13 @@ def test_sphinx_rinoh_logo_removed(caplog, tmp_path):
     with caplog.at_level(logging.WARNING):
         variable_removed_warnings(app.config, LOGGER)
     assert "Support for 'rinoh_logo' has been removed" in caplog.text
+
+
+def test_sphinx_rinoh_domain_indices_removed(caplog, tmp_path):
+    app = create_sphinx_app(tmp_path, rinoh_domain_indices=False)
+    with caplog.at_level(logging.WARNING):
+        variable_removed_warnings(app.config, LOGGER)
+    assert "Support for 'rinoh_domain_indices' has been removed" in caplog.text
 
 
 def test_sphinx_document_data_rinoh_documents(tmp_path):

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -162,9 +162,9 @@ def test_sphinx_set_document_metadata_subtitle(tmp_path):
 
 def test_sphinx_set_document_metadata_logo(tmp_path):
     expected_logo = 'logo.png'
-    app = create_sphinx_app(tmp_path, rinoh_logo=expected_logo)
+    app = create_sphinx_app(tmp_path)
     template_cfg = app.builder.template_configuration('book', LOGGER)
-    document_data = document_data_dict()
+    document_data = document_data_dict(logo=expected_logo)
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
     app.builder.set_document_metadata(rinoh_doc, document_data)
@@ -173,9 +173,9 @@ def test_sphinx_set_document_metadata_logo(tmp_path):
 
 def test_sphinx_set_document_metadata_logo_absolute(tmp_path):
     expected_logo = tmp_path / 'confdir' / 'logo.png'
-    app = create_sphinx_app(tmp_path, rinoh_logo=expected_logo)
+    app = create_sphinx_app(tmp_path)
     template_cfg = app.builder.template_configuration('book', LOGGER)
-    document_data = document_data_dict()
+    document_data = document_data_dict(logo=expected_logo)
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
     app.builder.set_document_metadata(rinoh_doc, document_data)
@@ -208,6 +208,13 @@ def test_sphinx_rinoh_paper_size_removed(caplog, tmp_path):
     with caplog.at_level(logging.WARNING):
         variable_removed_warnings(app.config, LOGGER)
     assert "Support for 'rinoh_paper_size' has been removed" in caplog.text
+
+
+def test_sphinx_rinoh_logo_removed(caplog, tmp_path):
+    app = create_sphinx_app(tmp_path, rinoh_logo='logo.png')
+    with caplog.at_level(logging.WARNING):
+        variable_removed_warnings(app.config, LOGGER)
+    assert "Support for 'rinoh_logo' has been removed" in caplog.text
 
 
 def test_sphinx_document_data_rinoh_documents(tmp_path):

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -42,14 +42,6 @@ def create_sphinx_app(tmp_path, all_docs=('index',), **confoverrides):
     return app
 
 
-def create_document(title='A Title', author='Ann Other', docname='a_name'):
-    document = new_document('/path/to/document.rst')
-    document.settings.title = title
-    document.settings.author = author
-    document.settings.docname = docname
-    return document
-
-
 def document_data_dict(**kwargs):
     document_data = {'doc': 'index', 'target': 'rinoh_doc', 'template': 'book',
                      'title': 'Title', 'author': 'Author', 'toctree_only': False}
@@ -139,10 +131,10 @@ def test_sphinx_config_rinoh_template_from_filename(tmp_path):
 def test_sphinx_set_document_metadata(tmp_path):
     app = create_sphinx_app(tmp_path, release='1.0', rinoh_template='book')
     template_cfg = app.builder.template_from_config(LOGGER)
-    docutils_tree = create_document()
+    document_data = document_data_dict(title='A Title', author="Ann Other")
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
-    app.builder.set_document_metadata(rinoh_doc, docutils_tree)
+    app.builder.set_document_metadata(rinoh_doc, document_data)
     assert rinoh_doc.metadata['title'] == 'A Title'
     assert rinoh_doc.metadata['subtitle'] == 'Release 1.0'
     assert rinoh_doc.metadata['author'] == 'Ann Other'
@@ -155,10 +147,10 @@ def test_sphinx_set_document_metadata_subtitle(tmp_path):
     app = create_sphinx_app(tmp_path, rinoh_metadata={
                             'subtitle': expected_subtitle})
     template_cfg = app.builder.template_from_config(LOGGER)
-    docutil_tree = create_document()
+    document_data = document_data_dict()
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
-    app.builder.set_document_metadata(rinoh_doc, docutil_tree)
+    app.builder.set_document_metadata(rinoh_doc, document_data)
     assert expected_subtitle == rinoh_doc.metadata['subtitle']
 
 
@@ -166,10 +158,10 @@ def test_sphinx_set_document_metadata_logo(tmp_path):
     expected_logo = 'logo.png'
     app = create_sphinx_app(tmp_path, rinoh_logo=expected_logo)
     template_cfg = app.builder.template_from_config(LOGGER)
-    docutil_tree = create_document()
+    document_data = document_data_dict()
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
-    app.builder.set_document_metadata(rinoh_doc, docutil_tree)
+    app.builder.set_document_metadata(rinoh_doc, document_data)
     assert Path(app.confdir) / expected_logo == rinoh_doc.metadata['logo']
 
 
@@ -177,10 +169,10 @@ def test_sphinx_set_document_metadata_logo_absolute(tmp_path):
     expected_logo = tmp_path / 'confdir' / 'logo.png'
     app = create_sphinx_app(tmp_path, rinoh_logo=expected_logo)
     template_cfg = app.builder.template_from_config(LOGGER)
-    docutil_tree = create_document()
+    document_data = document_data_dict()
     rinoh_tree = DocumentTree([])
     rinoh_doc = template_cfg.document(rinoh_tree)
-    app.builder.set_document_metadata(rinoh_doc, docutil_tree)
+    app.builder.set_document_metadata(rinoh_doc, document_data)
     assert expected_logo == rinoh_doc.metadata['logo']
 
 

--- a/tests_regression/helpers/regression.py
+++ b/tests_regression/helpers/regression.py
@@ -102,8 +102,6 @@ def render_sphinx_project(name, project_dir, template_cfg=None):
     project_path = TEST_DIR / project_dir
     out_path = OUTPUT_DIR / name
     confoverrides = {}
-    if template_cfg:
-        confoverrides['rinoh_template'] = str(TEST_DIR / template_cfg)
     with docutils_namespace():
         sphinx = Sphinx(srcdir=str(project_path),
                         confdir=str(project_path),
@@ -111,6 +109,9 @@ def render_sphinx_project(name, project_dir, template_cfg=None):
                         doctreedir=str(out_path / 'doctrees'),
                         buildername='rinoh',
                         confoverrides=confoverrides)
+        if template_cfg:
+            for document_data in sphinx.config.rinoh_documents:
+                document_data['template'] = str(TEST_DIR / template_cfg)
         sphinx.build()
     out_filename = '{}.pdf'.format(name)
     with in_directory(out_path):

--- a/tests_regression/roots/test-minimal/conf.py
+++ b/tests_regression/roots/test-minimal/conf.py
@@ -72,10 +72,9 @@ pygments_style = 'sphinx'
 # -- Options for rinohtype PDF output ----------------------------------------
 
 rinoh_documents = [{
-    'doc': master_doc,      # top-level file (index.rst)
-    'target': 'minimal',    # output (target.pdf)
-    'title': project,       # document title
-    'author': author,       # document author
+    'doc': master_doc,          # top-level file (index.rst)
+    'target': 'minimal',        # output (target.pdf)
+    'title': project,           # document title
+    'author': author,           # document author
+    'template': 'template.rtt'  # document template
 }]
-
-rinoh_template = 'template.rtt'

--- a/tests_regression/roots/test-minimal/conf.py
+++ b/tests_regression/roots/test-minimal/conf.py
@@ -71,11 +71,11 @@ pygments_style = 'sphinx'
 
 # -- Options for rinohtype PDF output ----------------------------------------
 
-rinoh_documents = [(
-    master_doc,           # top-level file (index.rst)
-    'minimal',            # output (target.pdf)
-    project,              # document title
-    author,               # document author
-)]
+rinoh_documents = [{
+    'doc': master_doc,      # top-level file (index.rst)
+    'target': 'minimal',    # output (target.pdf)
+    'title': project,       # document title
+    'author': author,       # document author
+}]
 
 rinoh_template = 'template.rtt'

--- a/tests_regression/roots/test-outoflineflowables/conf.py
+++ b/tests_regression/roots/test-outoflineflowables/conf.py
@@ -71,11 +71,12 @@ pygments_style = 'sphinx'
 
 # -- Options for rinohtype PDF output ----------------------------------------
 
-rinoh_documents = [(
-    master_doc,           # top-level file (index.rst)
-    'outoflineflowables', # output (target.pdf)
-    project,              # document title
-    author,               # document author
-)]
+rinoh_documents = [{
+    'doc': master_doc,              # top-level file (index.rst)
+    'target': 'outoflineflowables', # output (target.pdf)
+    'title': project,               # document title
+    'author': author,               # document author
+}]
+
 
 rinoh_template = 'template.rtt'

--- a/tests_regression/roots/test-outoflineflowables/conf.py
+++ b/tests_regression/roots/test-outoflineflowables/conf.py
@@ -76,7 +76,5 @@ rinoh_documents = [{
     'target': 'outoflineflowables', # output (target.pdf)
     'title': project,               # document title
     'author': author,               # document author
+    'template': 'template.rtt'      # document template
 }]
-
-
-rinoh_template = 'template.rtt'

--- a/tests_regression/roots/test-relativepaths/conf.py
+++ b/tests_regression/roots/test-relativepaths/conf.py
@@ -81,9 +81,6 @@ rinoh_documents = [{
     'target': 'relativepaths',                          # output (target.pdf)
     'title': project,                                   # document title
     'author': author,                                   # document author
-    'template': 'template_configuration/template.rtt'   # document template
+    'template': 'template_configuration/template.rtt',  # document template
+    'logo': 'logo.png'                                  # document logo
 }]
-
-rinoh_template = 'template_configuration/template.rtt'
-
-rinoh_logo = 'logo.png'

--- a/tests_regression/roots/test-relativepaths/conf.py
+++ b/tests_regression/roots/test-relativepaths/conf.py
@@ -76,12 +76,13 @@ pygments_style = 'sphinx'
 
 # -- Options for rinohtype PDF output ----------------------------------------
 
-rinoh_documents = [(
-    master_doc,           # top-level file (index.rst)
-    'relativepaths',      # output (target.pdf)
-    project,              # document title
-    author,               # document author
-)]
+rinoh_documents = [{
+    'doc': master_doc,                                  # top-level file (index.rst)
+    'target': 'relativepaths',                          # output (target.pdf)
+    'title': project,                                   # document title
+    'author': author,                                   # document author
+    'template': 'template_configuration/template.rtt'   # document template
+}]
 
 rinoh_template = 'template_configuration/template.rtt'
 

--- a/tests_regression/roots/test-subdir/conf.py
+++ b/tests_regression/roots/test-subdir/conf.py
@@ -71,11 +71,10 @@ pygments_style = 'sphinx'
 
 # -- Options for rinohtype PDF output ----------------------------------------
 
-rinoh_documents = [(
-    master_doc,           # top-level file (index.rst)
-    'subdir',             # output (target.pdf)
-    project,              # document title
-    author,               # document author
-)]
-
-rinoh_template = 'template.rtt'
+rinoh_documents = [{
+    'doc': master_doc,          # top-level file (index.rst)
+    'target': 'subdir',         # output (target.pdf)
+    'title': project,           # document title
+    'author': author,           # document author
+    'template': 'template.rtt'  # document template
+}]

--- a/tests_regression/sphinx_minimal/conf.py
+++ b/tests_regression/sphinx_minimal/conf.py
@@ -156,11 +156,12 @@ texinfo_documents = [
 
 # -- Options for rinohtype PDF output ----------------------------------------
 
-rinoh_documents = [(
-    master_doc,           # top-level file (index.rst)
-    'sphinx_minimal',     # output (target.pdf)
-    project,              # document title
-    author,               # document author
-)]
+rinoh_documents = [{
+    'doc': master_doc,              # top-level file (index.rst)
+    'target': 'sphinx_minimal',     # output (target.pdf)
+    'title': project,               # document title
+    'author': author,               # document author
+}]
+
 
 rinoh_template = 'book'


### PR DESCRIPTION
Finally got round to finishing this.

Changes in this PR:

* rinoh_documents are specified as a list of dicts
* removed support for rinoh_template
* removed support for rinoh_logo
* removed support for rinoh_domain_indices
* refactoring of sphinx frontend to aid in testing
* Updated docs

I have not been able to add unit tests for `write()`, `assemble_doctree()`, `generate_indices()`, etc. 
In my opinion the code needs to be restructured to make it easily testable and figuring out what needs to be done is beyond the scope of this change.
The result of this is the the rinoh_domain_indices change has only been tested by *manual inspection* in the debugger.