### PR TITLE
Update quickstart docs `rinoh_documents` syntax

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -48,7 +48,7 @@ will happily interpret :confval:`sphinx:latex_documents`. Otherwise, you need
 to set the :confval:`rinoh_documents` configuration option::
                         
     rinoh_documents = [dict(doc='index',        # top-level file (index.rst)
-                            target='manual')]    # output file (target.pdf)
+                            target='manual')]   # output file (target.pdf)
 
 Other configuration variables are optional and allow configuring the style of
 the generated PDF document. See :ref:`sphinx_builder` for details.

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -50,8 +50,8 @@ to set the :confval:`rinoh_documents` configuration option::
     rinoh_documents = [dict(doc='index',        # top-level file (index.rst)
                             target='manual')]   # output file (manual.pdf)
 
-The dictionary accepts optional keys besides the required *doc* and *target*
-keys. See :ref:`sphinx_builder` for details.
+The dictionary accepts optional keys in addition to the required *doc* and
+*target* keys. See :ref:`sphinx_builder` for details.
 
 When building the documentation, select the `rinoh` builder by passing it to
 the :option:`sphinx:sphinx-build -b` option::

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -46,7 +46,7 @@ Sphinx Builder
 If your Sphinx project is already configured for the LaTeX builder, rinohtype
 will happily interpret :confval:`sphinx:latex_documents`. Otherwise, you need
 to set the :confval:`rinoh_documents` configuration option::
-                        
+
     rinoh_documents = [dict(doc='index',        # top-level file (index.rst)
                             target='manual')]   # output file (target.pdf)
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -48,10 +48,10 @@ will happily interpret :confval:`sphinx:latex_documents`. Otherwise, you need
 to set the :confval:`rinoh_documents` configuration option::
 
     rinoh_documents = [dict(doc='index',        # top-level file (index.rst)
-                            target='manual')]   # output file (target.pdf)
+                            target='manual')]   # output file (manual.pdf)
 
-Other configuration variables are optional and allow configuring the style of
-the generated PDF document. See :ref:`sphinx_builder` for details.
+The dictionary accepts optional keys besides the required *doc* and *target*
+keys. See :ref:`sphinx_builder` for details.
 
 When building the documentation, select the `rinoh` builder by passing it to
 the :option:`sphinx:sphinx-build -b` option::

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -46,11 +46,9 @@ Sphinx Builder
 If your Sphinx project is already configured for the LaTeX builder, rinohtype
 will happily interpret :confval:`sphinx:latex_documents`. Otherwise, you need
 to set the :confval:`rinoh_documents` configuration option::
-
-    rinoh_documents = [('index',            # top-level file (index.rst)
-                        'target',           # output (target.pdf)
-                        'Document Title',   # document title
-                        'John A. Uthor')]   # document author
+                        
+    rinoh_documents = [dict(doc='index',        # top-level file (index.rst)
+                            target='manual')]    # output file (target.pdf)
 
 Other configuration variables are optional and allow configuring the style of
 the generated PDF document. See :ref:`sphinx_builder` for details.


### PR DESCRIPTION
The syntax for the `rinoh_documents` sphinx configuration option changed in 0.5.0.

The syntax used in the quickstart guide currently raises a depreciation warning. This PR updates the quickstart guide to use the new syntax.

Fixes #231 