### PR TITLE
In DynamicRinohDistribution, supply 'name' property with a unique value

### DIFF
--- a/src/rinoh/resource.py
+++ b/src/rinoh/resource.py
@@ -132,9 +132,7 @@ class DynamicEntryPoint(DynamicEntryPointBase):
 class DynamicRinohDistribution(ilm.Distribution):
     """Distribution for registering resource entry points to at runtime"""
 
-    @property
-    def name(self):
-        return 'rinoh-dynamic-distro'
+    name = 'rinoh-dynamic-distro'
 
     def __init__(self):
         self._templates = {}

--- a/src/rinoh/resource.py
+++ b/src/rinoh/resource.py
@@ -132,7 +132,9 @@ class DynamicEntryPoint(DynamicEntryPointBase):
 class DynamicRinohDistribution(ilm.Distribution):
     """Distribution for registering resource entry points to at runtime"""
 
-    name = ''
+    @property
+    def name(self):
+        return 'rinoh-dynamic-distro'
 
     def __init__(self):
         self._templates = {}


### PR DESCRIPTION
Supplies a text value instead of deferring to parent class, which resolves the value from metadata that isn't present. Workaround for [bpo-44459](https://bugs.python.org/issue44459).