### PR TITLE
Fix png iTXt compression_flag off-by-one error

### DIFF
--- a/src/rinoh/backend/pdf/xobject/purepng.py
+++ b/src/rinoh/backend/pdf/xobject/purepng.py
@@ -2563,12 +2563,13 @@ class Reader(object):
             keyword = str(keyword, 'latin-1')
         except:
             pass
-        if (data[i:i + 1] != zerobyte):
+        compress_flag = data[i + 1: i + 2]
+        if (compress_flag != zerobyte):
             # TODO: Support for compression!!
             return
         # TODO: Raise FormatError
-        assert (data[i + 1:i + 2] == zerobyte)
-        data_ = data[i + 3:]
+        compress_method = data[i + 2: i + 3]
+        assert (compress_method == zerobyte)
         i = data_.index(zerobyte)
         # skip language tag
         data_ = data_[i + 1:]

--- a/src/rinoh/backend/pdf/xobject/purepng.py
+++ b/src/rinoh/backend/pdf/xobject/purepng.py
@@ -2570,6 +2570,7 @@ class Reader(object):
         # TODO: Raise FormatError
         compress_method = data[i + 2: i + 3]
         assert (compress_method == zerobyte)
+        data_ = data[i + 3:]
         i = data_.index(zerobyte)
         # skip language tag
         data_ = data_[i + 1:]


### PR DESCRIPTION
This is the minimal fix required to support png files generated by plantuml as discussed in #272.

This change has been proposed upstream in https://github.com/Scondo/purepng. All tests that I was able to execute continue to pass (there appear to be undocumented dependencies on a specific version of PIL for some of the tests).

@brechtm do you intend to work on integrating PyPNG as mentioned in #274? If not, then I may take a look once I get plantuml sorted to my satisfaction.