### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/rinoh/backend/pdf/filter.py
+++ b/src/rinoh/backend/pdf/filter.py
@@ -96,7 +96,7 @@ class ASCIIHexEncoder(Encoder):
 class ASCIIHexDecoder(Decoder):
     def read(self, n=-1):
         # TODO: remove spaces
-        # TODO: handle odd-lenght input to unhexlify
+        # TODO: handle odd-length input to unhexlify
         # TODO: handler > EOD marker (also after odd-length string)
         return unhexlify(self._source.read(n))
 

--- a/src/rinoh/backend/pdf/xobject/purepng.py
+++ b/src/rinoh/backend/pdf/xobject/purepng.py
@@ -436,7 +436,7 @@ def check_time(value):
     if isinstance(value, basestring):
         if value.lower() == 'now':
             return time.gmtime()
-        # TODO: parsinng some popular strings
+        # TODO: parsing some popular strings
     raise ValueError("Unsupported time representation:" + repr(value))
 
 
@@ -856,11 +856,11 @@ class Writer(object):
         compression, with 9 being "more compressed" (usually smaller
         and slower, but it doesn't always work out that way).  0 means
         no compression.  -1 and ``None`` both mean that the default
-        level of compession will be picked by the ``zlib`` module
+        level of compression will be picked by the ``zlib`` module
         (which is generally acceptable).
 
         If `interlace` is true then an interlaced image is created
-        (using PNG's so far only interace method, *Adam7*).  This does
+        (using PNG's so far only interface method, *Adam7*).  This does
         not affect how the pixels should be presented to the encoder,
         rather it changes how they are arranged into the PNG file.
         On slow connexions interlaced images can be partially decoded

--- a/src/rinoh/layout.py
+++ b/src/rinoh/layout.py
@@ -18,7 +18,7 @@ page to which :class:`Flowable`\\ s can be rendered.
 * :class:`VirtualContainer`: A container who's rendered content is not
                              automatically placed on the page. Afterwards, it
                              can be manually placed, however.
-* :exc:`EndOfContainer`: Exception raised when a contianer "overflows" during
+* :exc:`EndOfContainer`: Exception raised when a container "overflows" during
                          the rendering of flowables.
 * :class:`Chain`: A chain of containers. When a container overflows, the
                   rendering of the chain's flowables is continued in the next

--- a/src/rinoh/paragraph.py
+++ b/src/rinoh/paragraph.py
@@ -264,7 +264,7 @@ class TabStop(object):
     Args:
         position (:class:`Dimension` or :class:`Fraction`): tab stop position
         align (TabAlign): the alignment of text with respect to the tab stop
-            positon
+            position
         fill (str): string pattern to fill the empty tab space with
 
     """

--- a/src/rinoh/util.py
+++ b/src/rinoh/util.py
@@ -268,7 +268,7 @@ class NotImplementedAttribute(object):
 class NamedDescriptor(object):
     """Base class for descriptor's whose name will be derived from the attribute
     name the descriptor instance is assigned to. The `name` attribute will hold
-    the desciptor name."""
+    the descriptor name."""
 
 
 class WithNamedDescriptors(type):


### PR DESCRIPTION
There are small typos in:
- src/rinoh/backend/pdf/filter.py
- src/rinoh/backend/pdf/xobject/purepng.py
- src/rinoh/layout.py
- src/rinoh/paragraph.py
- src/rinoh/util.py

Fixes:
- Should read `position` rather than `positon`.
- Should read `parsing` rather than `parsinng`.
- Should read `length` rather than `lenght`.
- Should read `interface` rather than `interace`.
- Should read `descriptor` rather than `desciptor`.
- Should read `container` rather than `contianer`.
- Should read `compression` rather than `compession`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md