### PR TITLE
Print alt text instead of error message when failing to render rst :image: directive

### DIFF
--- a/src/rinoh/frontend/rst/nodes.py
+++ b/src/rinoh/frontend/rst/nodes.py
@@ -612,7 +612,9 @@ class Image(DocutilsBodyNode, DocutilsInlineNode):
             width = width * scale if width else None
             height = height * scale if height else None
             scale = 1
-        return dict(align=align, width=width, height=height, scale=scale)
+        alt = self.get('alt')
+        return dict(align=align, width=width, height=height, scale=scale,
+                    alt=alt)
 
     def build_flowable(self):
         return rt.Image(self.image_path, **self.options)

--- a/src/rinoh/image.py
+++ b/src/rinoh/image.py
@@ -313,10 +313,10 @@ class InlineImage(ImageBase, InlineFlowable):
     arguments = InlineImageArgs
 
     def __init__(self, filename_or_file, scale=1.0, width=None, height=None,
-                 dpi=None, rotate=0, baseline=None,
+                 dpi=None, rotate=0, alt=None, baseline=None,
                  id=None, style=None, parent=None, source=None):
         super().__init__(filename_or_file=filename_or_file, scale=scale,
-                         height=height, dpi=dpi, rotate=rotate,
+                         height=height, dpi=dpi, rotate=rotate, alt=alt,
                          baseline=baseline, id=id, style=style, parent=parent,
                          source=source)
         self.width = width

--- a/src/rinoh/image.py
+++ b/src/rinoh/image.py
@@ -254,14 +254,14 @@ class ImageBase(Flowable):
             filename_or_file = self._absolute_path_or_file()
             image = container.document.backend.Image(filename_or_file)
         except OSError as err:
+            container.document.error = True
             message = "Error opening image file: {}".format(err)
             self.warn(message)
             if self.alt is None:
-                container.document.error = True
                 error = ErrorText(message)
                 return Paragraph(error).flow(container, last_descender)
             alt_text = MixedStyledText(self.alt)
-            return Paragraph(alt_text).flow(container, last_descender)
+            return Paragraph(alt_text, style='image alt').flow(container, last_descender)
         left, top = 0, float(container.cursor)
         width = self._width(container)
         try:

--- a/src/rinoh/image.py
+++ b/src/rinoh/image.py
@@ -199,7 +199,7 @@ class ImageBase(Flowable):
     arguments = ImageArgsBase
 
     def __init__(self, filename_or_file, scale=1.0, width=None, height=None,
-                 dpi=None, rotate=0, limit_width=None,
+                 dpi=None, rotate=0, limit_width=None, alt=None,
                  id=None, style=None, parent=None, source=None, **kwargs):
         super().__init__(id=id, style=style, parent=parent, source=source,
                          **kwargs)
@@ -217,6 +217,7 @@ class ImageBase(Flowable):
         self.dpi = dpi
         self.rotate = rotate
         self.limit_width = limit_width
+        self.alt = alt
 
     def copy(self, parent=None):
         return type(self)(self.filename_or_file, scale=self.scale,
@@ -253,11 +254,14 @@ class ImageBase(Flowable):
             filename_or_file = self._absolute_path_or_file()
             image = container.document.backend.Image(filename_or_file)
         except OSError as err:
-            container.document.error = True
             message = "Error opening image file: {}".format(err)
             self.warn(message)
-            error = ErrorText(message)
-            return Paragraph(error).flow(container, last_descender)
+            if self.alt is None:
+                container.document.error = True
+                error = ErrorText(message)
+                return Paragraph(error).flow(container, last_descender)
+            alt_text = MixedStyledText(self.alt)
+            return Paragraph(alt_text).flow(container, last_descender)
         left, top = 0, float(container.cursor)
         width = self._width(container)
         try:
@@ -331,10 +335,11 @@ class InlineImage(ImageBase, InlineFlowable):
 class _Image(ImageBase):
     def __init__(self, filename_or_file, scale=1.0, width=None, height=None,
                  dpi=None, rotate=0, limit_width=100*PERCENT, align=None,
+                 alt=None,
                  id=None, style=None, parent=None, source=None):
         super().__init__(filename_or_file=filename_or_file, scale=scale,
                          width=width, height=height, dpi=dpi, rotate=rotate,
-                         limit_width=limit_width, align=align,
+                         limit_width=limit_width, align=align, alt=alt,
                          id=id, style=style, parent=parent, source=source)
 
 

--- a/src/rinoh/stylesheets/matcher.py
+++ b/src/rinoh/stylesheets/matcher.py
@@ -304,7 +304,7 @@ matcher('figure image', 'figure' / Image)
 matcher('figure caption', 'figure' / Caption)
 matcher('figure legend', 'figure' / GroupedFlowables.like('legend'))
 matcher('figure legend paragraph', 'figure legend' / Paragraph)
-
+matcher('image alt', Paragraph.like('image alt'))
 
 # front matter
 


### PR DESCRIPTION
I've written this request as a proof of concept for my suggestion #409.
In this implementation, there is no possibility to disable that behaviour. I don't know how to connect that with a template option.

- Alternative text is displayed instead of an error message
- Changed rst frontend to write :alt: in Image