### PR TITLE
rinoh: all LinePart classes need hyphenate method

### DIFF
--- a/src/rinoh/paragraph.py
+++ b/src/rinoh/paragraph.py
@@ -469,9 +469,6 @@ class Space(SpecialCharacter):
         super().__init__(span, chars_to_glyphs)
         self.glyphs_span.append_space()
 
-    def hyphenate(self, container):
-        return iter([])
-
     def __getitem__(self, index):
         raise SpaceException
 

--- a/src/rinoh/paragraph.py
+++ b/src/rinoh/paragraph.py
@@ -446,7 +446,8 @@ def handle_missing_glyphs(span, container):
 
 
 class LinePart(object):
-    pass
+    def hyphenate(self, container):
+        return iter([])
 
 
 class SpecialCharacter(LinePart):


### PR DESCRIPTION
Fixes #415

I agree to the Contributor License Agreement.
I have tested this change locally using the files attached to issue 415.
Thank you!