### PR TITLE
Issue #420 - Fix for empty table body crash

### DIFF
--- a/src/rinoh/frontend/rst/nodes.py
+++ b/src/rinoh/frontend/rst/nodes.py
@@ -690,7 +690,10 @@ class Table(DocutilsBodyNode):
             head = tgroup.thead.get_table_section()
         except AttributeError:
             head = None
-        body = tgroup.tbody.get_table_section()
+        try:
+            body = tgroup.tbody.get_table_section()
+        except AttributeError:
+            body = None
         align = self.get('align')
         width_string = self.get('width')
         table = rt.Table(body, head=head,


### PR DESCRIPTION
Hi,

I've put together a fix for the empty table body crash from issue #420. I've done this by mostly copying the code rinoh uses when it encounters a table with an empty header and I've applied it to tables with empty bodies. 

This seems to fix the behavior so that it simply produces a table with only the header.
![image](https://github.com/brechtm/rinohtype/assets/87852659/2c626d4f-c0c9-4de4-a309-e3cc8bed3905)

As for a regression test, I failed to get one made as I could not quite get a comparison pdf created in the same "minimal template" style produced by the nox run. Maybe I'm missing something obvious but what is the best way to generate the pdf files in this style for these tests?

Just so its written down somewhere, the test content looks like:

```
.. csv-table::
    :header: "This", "table", "has", "no", "body", "rows!"
    :file: ./empty_body_table.csv
```

Where empty_body_table.csv is just an empty file
