### PR TITLE
If on Python 3.9+, set `usedforsecurity` parameter to `False`

### DIFF
--- a/src/rinoh/backend/pdf/cos.py
+++ b/src/rinoh/backend/pdf/cos.py
@@ -6,7 +6,7 @@
 # Public License v3. See the LICENSE file or http://www.gnu.org/licenses/.
 
 
-import hashlib, time
+import hashlib, time, sys
 
 from binascii import hexlify
 from codecs import BOM_UTF16_BE
@@ -566,7 +566,8 @@ class Document(dict):
         trailer['Size'] = Integer(self.max_identifier + 1)
         trailer['Root'] = self.catalog
         trailer['Info'] = self.info
-        md5sum = hashlib.md5()
+        # If using Python 3.9 or later, set usedforsecurity to False
+        md5sum = hashlib.md5() if sys.version_info < (3, 9) else hashlib.md5(usedforsecurity=False)
         md5sum.update(str(self.timestamp).encode())
         md5sum.update(str(file.tell()).encode())
         for value in self.info.values():


### PR DESCRIPTION
This is a small, backwards compatible change that allows the use of `rinohtype` in FIPS-enabled environments that raise errors when using the MD5 hashlib function. Since the purpose of using MD5 in this context is not security-related, this change is acceptable. The `usedforsecurity` parameter was added starting in Python 3.9+ for the `md5` function of the `hashlib` library.

An error like the following is otherwise thrown:
> digital envelope routines:EVP_DigestInit_ex:disabled for fips

An alternative could also be to call the SHA256 hashing function instead, but making this change keeps the current behavior of the `rinohtype` package.