### PR TITLE
Typo fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,7 +299,7 @@ New Features:
 * Enumerated list items with a hidden label ('hide' style attribute) are no
   longer counted in the numbering.
 * Templates and typefaces can be registered by name at runtime. This makes them
-  referencable from template configuration and style sheet files. For example,
+  referenceable from template configuration and style sheet files. For example,
   custom templates/typefaces can be imported in a Sphinx project's `conf.py`
   (to be documented).
 * It's now possible to add arbitrary reStructuredText content to the front/back

--- a/doc/basicstyling.rst
+++ b/doc/basicstyling.rst
@@ -215,7 +215,7 @@ command-line :program:`rinoh` tool by passing it to the
 :ref:`Sphinx_builder`, you can specify the template in the
 :confval:`rinoh_documents` option in ``conf.py``.
 
-To render a document using this template configuration programatically, load
+To render a document using this template configuration programmatically, load
 the template file using :class:`.TemplateConfigurationFile`:
 
 .. include:: testcode.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -398,7 +398,7 @@ epub_copyright = '2015, Brecht Machiels'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -5,7 +5,7 @@ Document Templates
 
 When it is not possible to achieve a particular document style using one of the
 existing templates and a custom template configuration, you can create a new
-template. A new template is programmed in Python and therefor it is required
+template. A new template is programmed in Python and therefore it is required
 that you are familiar with Python, or at least with general object-oriented
 programming.
 

--- a/examples/restructuredtext/FAQ.txt
+++ b/examples/restructuredtext/FAQ.txt
@@ -189,7 +189,7 @@ taken with capitalization, to avoid confusion with "REST__", an
 acronym for "Representational State Transfer".
 
 The abbreviations "reSTX" and "rSTX"/"rstx" should **not** be used;
-they overemphasize reStructuredText's precedessor, Zope's
+they overemphasize reStructuredText's predecessor, Zope's
 StructuredText.
 
 __ http://en.wikipedia.org/wiki/Representational_State_Transfer
@@ -300,7 +300,7 @@ charents naturally; instead of writing "&mdash;" you'd have to write
 "&amp;mdash;".
 
 For the common case of long dashes, you might also want to insert the
-following substitution definitons into your document (both of them are
+following substitution definitions into your document (both of them are
 using the "unicode_" directive)::
 
     .. |--| unicode:: U+2013   .. en dash
@@ -517,7 +517,7 @@ Could the requirement for blank lines around lists be relaxed?
 
 Short answer: no.
 
-In reStructuredText, it would be impossible to unambigously mark up
+In reStructuredText, it would be impossible to unambiguously mark up
 and parse lists without blank lines before and after.  Deeply nested
 lists may look ugly with so many blank lines, but it's a price we pay
 for unambiguous markup.  Some other plaintext markup systems do not
@@ -766,7 +766,7 @@ or geresh_) will suffice.
 
 Moreover, it's possible to translate_ all reStructuredText keywords.
 This was not yet done for any RTL language, but when it is, it will be
-possible to write an RTL document with vitually no English.  This will
+possible to write an RTL document with virtually no English.  This will
 allow reasonable use of editors limited to a single base direction for
 the whole document (like Notepad, Vim and text boxes in Firefox).
 
@@ -780,11 +780,11 @@ transparent implicit solution for HTML:
 * Grab http://cben-hacks.sourceforge.net/bidi/hibidi.py and
   http://cben-hacks.sourceforge.net/bidi/rst2html_hibidi.py.
   Put them both in the same directory and make them executable.
-  
+
 * Use ``rst2html_hibidi.py`` instead of ``rst2html.py``.
 
 * It infers dir attributes in the HTML from the text.  It does it
-  hierachically, giving much better results than usual.  You can still
+  hierarchically, giving much better results than usual.  You can still
   use LRM/RLM and LRE/RLE/PDF control codes to help it.
 
   * If you want the gory details: See the full theory_, and note the
@@ -819,7 +819,7 @@ classes in the HTML:
 
 * Select this new stylesheet with ``--stylesheet=<file>`` or the
   stylesheet_ setting.
-  
+
 * Now if you need to override the direction of some element (from a
   paragraph to a whole section), write::
 
@@ -1095,7 +1095,7 @@ spaces.  When encoded with UTF-8 and viewed with ordinary ASCII tools,
 these characters will appear to be multi-character garbage.
 
 You may have an decoding problem in your browser (or editor, etc.).
-The encoding of the output is set to "utf-8", but your browswer isn't
+The encoding of the output is set to "utf-8", but your browser isn't
 recognizing that.  You can either try to fix your browser (enable
 "UTF-8 character set", sometimes called "Unicode"), or choose a
 different encoding for the HTML output.  You can also try
@@ -1231,11 +1231,11 @@ the reStructuredText markup.
 .. Here's a code css to make a table colourful::
 
    /* Table: */
-   
+
    th {
        background-color: #ede;
    }
-   
+
    /* alternating colors in table rows */
    table.docutils tr:nth-child(even) {
        background-color: #F3F3FF;
@@ -1243,9 +1243,9 @@ the reStructuredText markup.
    table.docutils tr:nth-child(odd) {
        background-color: #FFFFEE;
    }
-   
+
    table.docutils tr {
        border-style: solid none solid none;
        border-width: 1px 0 1px 0;
        border-color: #AAAAAA;
-   }  
+   }

--- a/examples/restructuredtext/quickstart.txt
+++ b/examples/restructuredtext/quickstart.txt
@@ -345,7 +345,7 @@ example::
     ...
 
 Note that "Document Title" and "Section Title" above both use equals
-signs, but are distict and unrelated styles.  The text of
+signs, but are distinct and unrelated styles.  The text of
 overline-and-underlined titles (but not underlined-only) may be inset
 for aesthetics.
 

--- a/src/rinoh/backend/pdf/pdfdoccodec.py
+++ b/src/rinoh/backend/pdf/pdfdoccodec.py
@@ -84,7 +84,7 @@ decoding_table = (
     '\ufffe'    #  0x13 -> (DEVICE CONTROL THREE)
     '\ufffe'    #  0x14 -> (DEVICE CONTROL FOUR)
     '\ufffe'    #  0x15 -> (NEGATIVE ACKNOWLEDGE)
-    '\ufffe'    #  0x16 -> (SYNCRONOUS IDLE)
+    '\ufffe'    #  0x16 -> (SYNCHRONOUS IDLE)
     '\ufffe'    #  0x17 -> (END OF TRANSMISSION BLOCK)
     '\u02d8'    #  0x18 -> BREVE
     '\u02c7'    #  0x19 -> CARON

--- a/src/rinoh/backend/pdf/reader.py
+++ b/src/rinoh/backend/pdf/reader.py
@@ -492,7 +492,7 @@ class FreeObjectEntry(XRefEntry):
         self.generation = generation
 
     def get_object(self, document):
-        raise Exception('Cannot retieve a free object with id {}'
+        raise Exception('Cannot retrieve a free object with id {}'
                         .format(self.identifier))
 
 

--- a/src/rinoh/backend/pdf/xobject/purepng.py
+++ b/src/rinoh/backend/pdf/xobject/purepng.py
@@ -269,7 +269,7 @@ except NameError:
         """
         Convert bytearray to bytes.
 
-        Recal that `row` will actually be an ``array``.
+        Recall that `row` will actually be an ``array``.
         """
         return row.tostring()
 
@@ -901,11 +901,11 @@ class Writer(object):
 
         if 'resolution' not in kwargs and 'physical' in kwargs:
             kwargs['resolution'] = kwargs.pop('physical')
-            warnings.warn('please use resolution instead of physilcal',
+            warnings.warn('please use resolution instead of physical',
                           DeprecationWarning)
 
         if not isinteger(bitdepth) or bitdepth < 1 or 16 < bitdepth:
-            raise ValueError("bitdepth (%r) must be a postive integer <= 16" %
+            raise ValueError("bitdepth (%r) must be a positive integer <= 16" %
               bitdepth)
 
         self.pixbitdepth = bitdepth
@@ -981,7 +981,7 @@ class Writer(object):
         """
         Add ICC Profile.
 
-        Prefered way is tuple (`profile_name`, `profile_bytes`), but only
+        Preferred way is tuple (`profile_name`, `profile_bytes`), but only
         bytes with name as separate argument is also supported.
         """
         if isinstance(profile, (basestring, bytes)):
@@ -1057,7 +1057,7 @@ class Writer(object):
         """
         Add physical pixel dimensions
 
-        `resolution` supposed two be tuple of two parameterts: pixels per unit
+        `resolution` supposed two be tuple of two parameters: pixels per unit
         and unit type; unit type may be omitted
         pixels per unit could be simple integer or tuple of (ppu_x, ppu_y)
         Also possible to use all three parameters im row
@@ -1470,7 +1470,7 @@ class Writer(object):
             if len(data) > self.chunk_limit:
                 yield bytearray_to_bytes(data)
                 # Because of our very witty definition of ``extend``,
-                # above, we must re-use the same ``data`` object.  Hence
+                # above, we must reuse the same ``data`` object.  Hence
                 # we use ``del`` to empty this one, rather than create a
                 # fresh one (which would be my natural FP instinct).
                 del data[:]
@@ -1737,7 +1737,7 @@ class Filter(BaseFilter):
 
         `filter_type` may be integer to apply basic filter or
         adaptive strategy with dict
-        (`name` is reqired field, others may tune strategy)
+        (`name` is required field, others may tune strategy)
         """
         # Recall that filtering algorithms are applied to bytes,
         # not to pixels, regardless of the bit depth or colour type
@@ -1761,7 +1761,7 @@ class Filter(BaseFilter):
 
 def register_extra_filter(selector, name):
     """
-    Register adaptive filter selection strategy for futher usage.
+    Register adaptive filter selection strategy for further usage.
 
     `selector` - callable like ``def(line, cfg, filter_obj)``
 
@@ -2612,7 +2612,7 @@ class Reader(object):
 
     def idatdecomp(self, lenient=False, max_length=0):
         """Iterator that yields decompressed ``IDAT`` strings."""
-        # Currently, with no max_length paramter to decompress, this
+        # Currently, with no max_length parameter to decompress, this
         # routine will do one yield per IDAT chunk.  So not very
         # incremental.
         d = zlib.decompressobj()

--- a/src/rinoh/flowable.py
+++ b/src/rinoh/flowable.py
@@ -497,7 +497,7 @@ class GroupedFlowables(Flowable):
     """Groups a list of flowables and renders them one below the other.
 
     Makes sure that a flowable for which `keep_with_next` is enabled is not
-    seperated from the flowable that follows it.
+    separated from the flowable that follows it.
 
     Subclasses should implement :meth:`flowables`.
 

--- a/src/rinoh/font/opentype/gsub.py
+++ b/src/rinoh/font/opentype/gsub.py
@@ -32,7 +32,7 @@ class SingleSubTable(MultiFormatTable):
             return self['Substitute'][index]
 
 
-# Multiple subtitution (subtable format 2)
+# Multiple substitution (subtable format 2)
 class Sequence(OpenTypeTable):
     entries = [('GlyphCount', uint16),
                ('Substitute', context_array(glyph_id, 'GlyphCount'))]
@@ -52,7 +52,7 @@ class MultipleSubTable(OpenTypeTable):
         raise NotImplementedError
 
 
-# Alternate subtitution (subtable format 3)
+# Alternate substitution (subtable format 3)
 class AlternateSubTable(OpenTypeTable):
     pass
 

--- a/src/rinoh/language/es.py
+++ b/src/rinoh/language/es.py
@@ -9,6 +9,7 @@
 from .cls import Language
 from ..structure import SectionTitles, AdmonitionTitles
 
+
 ES = Language('es', 'Spanish')
 
 SectionTitles(

--- a/src/rinoh/layout.py
+++ b/src/rinoh/layout.py
@@ -468,7 +468,7 @@ class UpExpandingContainer(_FlowablesContainer, ExpandingContainerBase):
 
 
 class UpDownExpandingContainer(_FlowablesContainer, ExpandingContainerBase):
-    """A container that is anchored in the middle and symetrically expands
+    """A container that is anchored in the middle and symmetrically expands
     upwards and downwards."""
 
     def __init__(self, name, type, parent, left=None, middle=None, width=None,


### PR DESCRIPTION
Some easy typo fixes (found thanks to the `codespell` library)