### PR TITLE
Defined GroupedFlowablesState.content_flowable_state returning self

### DIFF
--- a/src/rinoh/flowable.py
+++ b/src/rinoh/flowable.py
@@ -460,6 +460,10 @@ class GroupedFlowablesState(FlowableState):
     def at_end(self):
         return self._index >= len(self.flowables)
 
+    @property
+    def content_flowable_state(self):
+        return self
+
     def __copy__(self):
         copy_flowables = copy(self.flowables)
         copy_first_flowable_state = copy(self.first_flowable_state)


### PR DESCRIPTION
Prevent this kind of error:
```
# Platform:         linux; (Linux-5.15.0-126-generic-x86_64-with-glibc2.35)
# Sphinx version:   7.2.6
# Python version:   3.10.12 (CPython)
# Docutils version: 0.20.1
# Jinja2 version:   3.1.2
# Pygments version: 2.17.2

# Last messages:
#   mdf/acquisition/fleximeter
#   mdf/browser/browser
#   mdf/graphics/index
#   mdf/graphics/graphics
#   mdf/graphics/navigator
#   mdf/graphics/fleximeter-correction
#   mdf/graphics/coupling-temperature
#   mdf/support/support
#   resolving references...
#   rendering...

# Loaded extensions:
#   sphinx.ext.mathjax (7.2.6)
#   alabaster (0.7.13)
#   sphinxcontrib.applehelp (1.0.7)
#   sphinxcontrib.devhelp (1.0.5)
#   sphinxcontrib.htmlhelp (2.0.4)
#   sphinxcontrib.serializinghtml (1.1.9)
#   sphinxcontrib.qthelp (1.0.6)
#   rinoh.frontend.sphinx (0.5.5)

# Traceback:
Traceback (most recent call last):
  File "/home/daniele/.local/lib/python3.10/site-packages/sphinx/cmd/build.py", line 298, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/daniele/.local/lib/python3.10/site-packages/sphinx/application.py", line 355, in build
    self.builder.build_update()
  File "/home/daniele/.local/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 290, in build_update
    self.build(['__all__'], to_build)
  File "/home/daniele/.local/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 363, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/frontend/sphinx/__init__.py", line 257, in write
    self.write_document(entry)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/frontend/sphinx/__init__.py", line 267, in write_document
    rinoh_document.render(outfilename)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/document.py", line 443, in render
    self.part_page_counts = self._render_pages()
  File "/usr/local/lib/python3.10/dist-packages/rinoh/document.py", line 485, in _render_pages
    part_page_count += part.render(part_page_count.count + 1)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/template.py", line 449, in render
    page.render()
  File "/usr/local/lib/python3.10/dist-packages/rinoh/document.py", line 178, in render
    super().render(CONTENT, rerender=index > 0)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/layout.py", line 197, in render
    child.render(type, rerender)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/layout.py", line 197, in render
    child.render(type, rerender)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/layout.py", line 306, in render
    self._render(type, rerender)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/layout.py", line 366, in _render
    self.chain.render(self, rerender=rerender)
  File "/usr/local/lib/python3.10/dist-packages/rinoh/layout.py", line 637, in render
    self.flowables.flow(container, last_descender=None,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 840, in render
    return super().render(container, descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 534, in render
    self._flow_with_next(state, container, descender,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 571, in _flow_with_next
    flowable.flow(maybe_container, descender, state=flowable_state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 239, in flow
    self.flow_inner(margin_container, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 294, in flow_inner
    self.render(pad_cntnr, last_descender, state=state,
  File "/usr/local/lib/python3.10/dist-packages/rinoh/flowable.py", line 749, in render
    content_state_copy = copy(state.content_flowable_state)
AttributeError: 'GroupedFlowablesState' object has no attribute 'content_flowable_state'
```