### PR TITLE
Security: Command injection risk in privileged shell command construction

### DIFF
--- a/macapp/src/rinoh_macapp/app.py
+++ b/macapp/src/rinoh_macapp/app.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 
 
@@ -28,6 +29,9 @@ if __name__ == '__main__':
         rinoh_path = os.path.join(script_dir, 'rinoh.sh')
         link_path = os.path.join(TARGET_DIR, 'rinoh')
         create_link = ('mkdir -p {} && ln -sfh {} {}'
-                       .format(TARGET_DIR, rinoh_path, link_path))
+                       .format(shlex.quote(TARGET_DIR),
+                               shlex.quote(rinoh_path),
+                               shlex.quote(link_path)))
         run_apple_script('do shell script "{}" with administrator privileges'
-                         .format(create_link))
+                         .format(create_link.replace('\\', '\\\\')
+                                            .replace('"', '\\"')))


### PR DESCRIPTION
## Summary

Security: Command injection risk in privileged shell command construction

## Problem

**Severity**: `High` | **File**: `macapp/src/rinoh_macapp/app.py:L29`

The macOS helper builds a shell command string (`create_link`) using `.format()` and then executes it via AppleScript `do shell script ... with administrator privileges`. Because arguments are interpolated into a single shell string without robust escaping/quoting, a path containing shell metacharacters (for example, a crafted app install path with quotes or `;`) could alter the command executed as admin.

## Solution

Avoid building a shell command string. Execute privileged operations with argument-safe APIs (e.g., a dedicated helper binary/script invoked with fixed argv), or strictly shell-escape each value with `shlex.quote()` before interpolation. Also validate that `rinoh_path` and `link_path` contain only expected characters.

## Changes

- `macapp/src/rinoh_macapp/app.py` (modified)